### PR TITLE
Introduce preprocessor flag DEBUG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 CXX ?= g++
+CPPFLAGS='-DDEBUG'
 CFLAGS = -Wall -Wconversion -O3 -fPIC
 SHVER = 2
 OS = $(shell uname)

--- a/svm.cpp
+++ b/svm.cpp
@@ -44,7 +44,7 @@ static void print_string_stdout(const char *s)
 	fflush(stdout);
 }
 static void (*svm_print_string) (const char *) = &print_string_stdout;
-#if 1
+#ifdef DEBUG
 static void info(const char *fmt,...)
 {
 	char buf[BUFSIZ];


### PR DESCRIPTION
CPPFLAGS = '-DDEBUG' can be used to turn on debug output for library functions. This makes
packaging easier, where it's generally not desired.
