### PR TITLE
Check return value of setlocale().

### DIFF
--- a/svm.cpp
+++ b/svm.cpp
@@ -2643,7 +2643,10 @@ int svm_save_model(const char *model_file_name, const svm_model *model)
 	FILE *fp = fopen(model_file_name,"w");
 	if(fp==NULL) return -1;
 
-	char *old_locale = strdup(setlocale(LC_ALL, NULL));
+	char *old_locale = setlocale(LC_ALL, NULL);
+	if (old_locale) {
+		old_locale = strdup(old_locale);
+	}
 	setlocale(LC_ALL, "C");
 
 	const svm_parameter& param = model->param;
@@ -2875,7 +2878,10 @@ svm_model *svm_load_model(const char *model_file_name)
 	FILE *fp = fopen(model_file_name,"rb");
 	if(fp==NULL) return NULL;
 
-	char *old_locale = strdup(setlocale(LC_ALL, NULL));
+	char *old_locale = setlocale(LC_ALL, NULL);
+	if (old_locale) {
+		old_locale = strdup(old_locale);
+	}
 	setlocale(LC_ALL, "C");
 
 	// read parameters


### PR DESCRIPTION
setlocale() is allowed to return NULL.  In particular, this happens on
Bionic (Android's libc) because it doesn't support C locales.