### PR TITLE
Matlab: include 'svm.h' instead of '../svm.h'

### DIFF
--- a/matlab/make.m
+++ b/matlab/make.m
@@ -6,15 +6,15 @@ try
 	if(strcmp(Type(1).Name, 'Octave') == 1)
 		mex libsvmread.c
 		mex libsvmwrite.c
-		mex svmtrain.c ../svm.cpp svm_model_matlab.c
-		mex svmpredict.c ../svm.cpp svm_model_matlab.c
+		mex -I.. svmtrain.c ../svm.cpp svm_model_matlab.c
+		mex -I.. svmpredict.c ../svm.cpp svm_model_matlab.c
 	% This part is for MATLAB
 	% Add -largeArrayDims on 64-bit machines of MATLAB
 	else
 		mex CFLAGS="\$CFLAGS -std=c99" -largeArrayDims libsvmread.c
 		mex CFLAGS="\$CFLAGS -std=c99" -largeArrayDims libsvmwrite.c
-		mex CFLAGS="\$CFLAGS -std=c99" -largeArrayDims svmtrain.c ../svm.cpp svm_model_matlab.c
-		mex CFLAGS="\$CFLAGS -std=c99" -largeArrayDims svmpredict.c ../svm.cpp svm_model_matlab.c
+		mex CFLAGS="\$CFLAGS -std=c99" -I.. -largeArrayDims svmtrain.c ../svm.cpp svm_model_matlab.c
+		mex CFLAGS="\$CFLAGS -std=c99" -I.. -largeArrayDims svmpredict.c ../svm.cpp svm_model_matlab.c
 	end
 catch
 	fprintf('If make.m fails, please check README about detailed instructions.\n');

--- a/matlab/svm_model_matlab.c
+++ b/matlab/svm_model_matlab.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
-#include "../svm.h"
+#include "svm.h"
 
 #include "mex.h"
 

--- a/matlab/svmpredict.c
+++ b/matlab/svmpredict.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "../svm.h"
+#include "svm.h"
 
 #include "mex.h"
 #include "svm_model_matlab.h"

--- a/matlab/svmtrain.c
+++ b/matlab/svmtrain.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
-#include "../svm.h"
+#include "svm.h"
 
 #include "mex.h"
 #include "svm_model_matlab.h"


### PR DESCRIPTION
The Matlab Makefile already has .. on the -I option for the compiler
so this was not required.  This was only required for the make.m Matlab
and Octave script, so it was modified to include .. on the search path.

This change is required to build the mex files using a libsvm library
different than the one in this distribution.  Maybe a system-wide install
of libsvm, or just another version for testing.