### PR TITLE
Removed the '-1' key in the support vector representation.

### DIFF
--- a/python/svm.py
+++ b/python/svm.py
@@ -282,9 +282,9 @@ class svm_model(Structure):
 
 			i = 0
 			while True:
-				row[sparse_sv[i].index] = sparse_sv[i].value
 				if sparse_sv[i].index == -1:
 					break
+				row[sparse_sv[i].index] = sparse_sv[i].value
 				i += 1
 
 			result.append(row)


### PR DESCRIPTION
The function get_SV() in svm.py returns the support vectors.
It accidently adds a '-1' key in the dictionary that represents
a support vector.

The '-1' is used by the C implementation to denote the last
svm_node of a vector in the training set x.
