### PR TITLE
easy.py change - fixes #42

### DIFF
--- a/tools/easy.py
+++ b/tools/easy.py
@@ -49,7 +49,7 @@ cmd = '{0} -s "{1}" "{2}" > "{3}"'.format(svmscale_exe, range_file, train_pathna
 print('Scaling training data...')
 Popen(cmd, shell = True, stdout = PIPE).communicate()	
 
-cmd = '{0} -svmtrain "{1}" -gnuplot "{2}" "{3}"'.format(grid_py, svmtrain_exe, gnuplot_exe, scaled_file)
+cmd = 'python {0} -svmtrain "{1}" -gnuplot "{2}" "{3}"'.format(grid_py, svmtrain_exe, gnuplot_exe, scaled_file)
 print('Cross validation...')
 f = Popen(cmd, shell = True, stdout = PIPE).stdout
 


### PR DESCRIPTION
The ValueError being thrown is because grid.py is not executable. This change fixes that issue.

This has been discussed prior:
https://github.com/shackenberg/Minimal-Bag-of-Visual-Words-Image-Classifier/issues/2 [English]
http://www.cnblogs.com/zklidd/p/3990915.html [Chinese]