### PR TITLE
Corrected typo in argument syntax for calling svmtrain.m

### DIFF
--- a/matlab/README
+++ b/matlab/README
@@ -80,7 +80,7 @@ http://www.mathworks.com/support/compilers/current_release/
 Usage
 =====
 
-matlab> model = svmtrain(training_label_vector, training_instance_matrix [, 'libsvm_options']);
+matlab> model = svmtrain(training_label_vector, training_instance_matrix, ['libsvm_options']);
 
         -training_label_vector:
             An m by 1 vector of training labels (type must be double).
@@ -90,8 +90,8 @@ matlab> model = svmtrain(training_label_vector, training_instance_matrix [, 'lib
         -libsvm_options:
             A string of training options in the same format as that of LIBSVM.
 
-matlab> [predicted_label, accuracy, decision_values/prob_estimates] = svmpredict(testing_label_vector, testing_instance_matrix, model [, 'libsvm_options']);
-matlab> [predicted_label] = svmpredict(testing_label_vector, testing_instance_matrix, model [, 'libsvm_options']);
+matlab> [predicted_label, accuracy, decision_values/prob_estimates] = svmpredict(testing_label_vector, testing_instance_matrix, model, ['libsvm_options']);
+matlab> [predicted_label] = svmpredict(testing_label_vector, testing_instance_matrix, model, ['libsvm_options']);
 
         -testing_label_vector:
             An m by 1 vector of prediction labels. If labels of test


### PR DESCRIPTION
@cjlin1 I think the square bracket should wrap the string `libsvm_options`, and the comma should separate that string argument from the prior argument `training_instance_matrix`.

But I could be wrong! Just checking...