### PR TITLE
zero initialize new svm_model

### DIFF
--- a/svm.cpp
+++ b/svm.cpp
@@ -37,6 +37,7 @@ static inline double powi(double base, int times)
 #define INF HUGE_VAL
 #define TAU 1e-12
 #define Malloc(type,n) (type *)malloc((n)*sizeof(type))
+#define Calloc(type,n) (type *)calloc(n,sizeof(type))
 
 static void print_string_stdout(const char *s)
 {
@@ -2886,14 +2887,8 @@ svm_model *svm_load_model(const char *model_file_name)
 
 	// read parameters
 
-	svm_model *model = Malloc(svm_model,1);
-	model->rho = NULL;
-	model->probA = NULL;
-	model->probB = NULL;
-	model->sv_indices = NULL;
-	model->label = NULL;
-	model->nSV = NULL;
-	
+	svm_model *model = Calloc(svm_model,1);
+
 	// read header
 	if (!read_model_header(fp, model))
 	{


### PR DESCRIPTION
 zero initialize new svm_model to ensure all sizes (including m.param.nr_weight) default to 0 and pointers are null.

without this change, svm_load_model returns a model with an unitialized param.nr_weight, causing any attempt at externalizing the structure to another language to incorrectly determine the length of param.weight_label and param.weight.