### PR TITLE
Prevent memory corruption when large kernel params cause numerical instability

### DIFF
--- a/svm.cpp
+++ b/svm.cpp
@@ -874,6 +874,11 @@ int Solver::select_working_set(int &out_i, int &out_j)
 		}
 	}
 
+	if (Gmax_idx < 0 || Gmin_idx < 0)
+	{
+		fprintf(stderr,"\nWARNING: Numerical instability.\n");
+		return 1;
+	}
 	if(Gmax+Gmax2 < eps || Gmin_idx == -1)
 		return 1;
 


### PR DESCRIPTION
This can be observed in R's e1071 package, which uses libsvm. The following causes a segfault on linux x86_64:

```R
svm(x=matrix(c(20, rep(13:15, 37)), ncol=4), y=rep(1:2, each=14),
    kernel="polynomial", degree=10, gamma=9.39, scale=FALSE)
```