### PR TITLE
Add function to release memory used by svm_problem

### DIFF
--- a/svm.cpp
+++ b/svm.cpp
@@ -3043,6 +3043,16 @@ void svm_destroy_param(svm_parameter* param)
 	free(param->weight);
 }
 
+void svm_destroy_problem(svm_problem *problem)
+{
+    delete [] problem->y;
+    problem->y = NULL;
+    for(int i=0;i<problem->l;i++)
+        delete [] problem->x[i];
+    delete [] problem->x;
+    problem->x = NULL;
+}
+
 const char *svm_check_parameter(const svm_problem *prob, const svm_parameter *param)
 {
 	// svm_type

--- a/svm.h
+++ b/svm.h
@@ -91,6 +91,7 @@ double svm_predict_probability(const struct svm_model *model, const struct svm_n
 void svm_free_model_content(struct svm_model *model_ptr);
 void svm_free_and_destroy_model(struct svm_model **model_ptr_ptr);
 void svm_destroy_param(struct svm_parameter *param);
+void svm_destroy_problem(svm_problem *problem);
 
 const char *svm_check_parameter(const struct svm_problem *prob, const struct svm_parameter *param);
 int svm_check_probability_model(const struct svm_model *model);


### PR DESCRIPTION
Hi,
     I was working on a project using libsvm and you have a structure svm_problem which contains two pointers. To release the resources held by the structure I have added a function svm_destroy_problem.

I don't know what coding conventions are used by libsvm and might have used the wrong conventions. Please let me know if the function is appropriate for your use and if any changes are to be made.

Thanks.