### PR TITLE
Java svm uses faster `Math.pow` instead of `powi`

### DIFF
--- a/java/libsvm/svm.java
+++ b/java/libsvm/svm.java
@@ -152,18 +152,6 @@ abstract class Kernel extends QMatrix {
 		if(x_square != null) do {double tmp=x_square[i]; x_square[i]=x_square[j]; x_square[j]=tmp;} while(false);
 	}
 
-	private static double powi(double base, int times)
-	{
-		double tmp = base, ret = 1.0;
-
-		for(int t=times; t>0; t/=2)
-		{
-			if(t%2==1) ret*=tmp;
-			tmp = tmp * tmp;
-		}
-		return ret;
-	}
-
 	double kernel_function(int i, int j)
 	{
 		switch(kernel_type)
@@ -171,7 +159,7 @@ abstract class Kernel extends QMatrix {
 			case svm_parameter.LINEAR:
 				return dot(x[i],x[j]);
 			case svm_parameter.POLY:
-				return powi(gamma*dot(x[i],x[j])+coef0,degree);
+				return Math.pow(gamma*dot(x[i],x[j])+coef0,degree);
 			case svm_parameter.RBF:
 				return Math.exp(-gamma*(x_square[i]+x_square[j]-2*dot(x[i],x[j])));
 			case svm_parameter.SIGMOID:
@@ -231,7 +219,7 @@ abstract class Kernel extends QMatrix {
 			case svm_parameter.LINEAR:
 				return dot(x,y);
 			case svm_parameter.POLY:
-				return powi(param.gamma*dot(x,y)+param.coef0,param.degree);
+				return Math.pow(param.gamma*dot(x,y)+param.coef0,param.degree);
 			case svm_parameter.RBF:
 			{
 				double sum = 0;

--- a/java/libsvm/svm.m4
+++ b/java/libsvm/svm.m4
@@ -152,18 +152,6 @@ abstract class Kernel extends QMatrix {
 		if(x_square != null) swap(double,x_square[i],x_square[j]);
 	}
 
-	private static double powi(double base, int times)
-	{
-		double tmp = base, ret = 1.0;
-
-		for(int t=times; t>0; t/=2)
-		{
-			if(t%2==1) ret*=tmp;
-			tmp = tmp * tmp;
-		}
-		return ret;
-	}
-
 	double kernel_function(int i, int j)
 	{
 		switch(kernel_type)
@@ -171,7 +159,7 @@ abstract class Kernel extends QMatrix {
 			case svm_parameter.LINEAR:
 				return dot(x[i],x[j]);
 			case svm_parameter.POLY:
-				return powi(gamma*dot(x[i],x[j])+coef0,degree);
+				return Math.pow(gamma*dot(x[i],x[j])+coef0,degree);
 			case svm_parameter.RBF:
 				return Math.exp(-gamma*(x_square[i]+x_square[j]-2*dot(x[i],x[j])));
 			case svm_parameter.SIGMOID:
@@ -231,7 +219,7 @@ abstract class Kernel extends QMatrix {
 			case svm_parameter.LINEAR:
 				return dot(x,y);
 			case svm_parameter.POLY:
-				return powi(param.gamma*dot(x,y)+param.coef0,param.degree);
+				return Math.pow(param.gamma*dot(x,y)+param.coef0,param.degree);
 			case svm_parameter.RBF:
 			{
 				double sum = 0;


### PR DESCRIPTION
Using the built-in `Math.pow` method instead of svm's custom `powi`. This makes the code faster.

I checked this by sampling svm prediction with `jvisualvm`. `powi` used to take about 8-10% of the CPU time (with `Kernel.dot` taking 66-73%). After changing it to `Math.pow` the time it takes is negligible.