### PR TITLE
Add setup.py and release script for pypi

### DIFF
--- a/python/release.sh
+++ b/python/release.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+python setup.py sdist
+
+if [ $1 == "test" ];
+ then
+    echo TEST RELEASE;
+    twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+else
+    echo PROD RELEASE;
+    twine upload dist/*.tar.gz
+fi

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,34 @@
+# coding=utf-8
+"""Setup file for distutils / pypi."""
+try:
+    from ez_setup import use_setuptools
+    use_setuptools()
+except ImportError:
+    pass
+
+from setuptools import setup
+
+
+setup(
+    name='libsvm',
+    version='3.23',
+    author='Chih-Chung Chang and Chih-Jen Lin',
+    py_modules=['svm', 'svmutil', 'commonutil'],
+    url='https://www.csie.ntu.edu.tw/~cjlin/libsvm/',
+    description=('Python binding for libsvm ('
+                 'https://www.csie.ntu.edu.tw/~cjlin/libsvm/).'),
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Topic :: Scientific/Engineering',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+
+    ]
+)


### PR DESCRIPTION
Hi @cjlin1, this PR is to add setup.py and release script for python bindings so that we can get them easily from pypi. The motivation behind this is:

- python-libsvm from apt does not link to the active python environment (tried several times on different containers, and only linked to python 2.7)
- Package to fix similar problem is out there (e.g https://github.com/Salinger/libsvm-python), but would be nice that this binding is rather streamlined with this project and always updated to the current version.
- Having this binding on pypi would fix another problem on some situation: e.g in pybrisque (https://github.com/bukalapak/pybrisque/blob/master/setup.py), we want libsvm's python binding to be installed right away when user installs pybrisque, but since it's not on pypi, we had to do it using dependency-links. But since process-dependency-links is obsolete in pip >= 19, we couldn't do this anymore. Of course we can alway ask users to install the binding separately, but the former is just easier to the user.

Thank you. Cheers 