### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README
+++ b/README
@@ -48,7 +48,7 @@ You can download and install libsvm using the [vcpkg](https://github.com/Microso
     cd vcpkg
     ./bootstrap-vcpkg.sh
     ./vcpkg integrate install
-    vcpkg install libsvm
+    ./vcpkg install libsvm
 
 The libsvm port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 

--- a/README
+++ b/README
@@ -39,6 +39,19 @@ Usage: easy.py training_file [testing_file]
 More information about parameter selection can be found in
 `tools/README.'
 
+Building libsvm - Using vcpkg
+=============================
+
+You can download and install libsvm using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install libsvm
+
+The libsvm port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Installation and Data Format
 ============================
 


### PR DESCRIPTION
Libsvm is available as a port in vcpkg, a C++ library manager that simplifies installation for libsvm and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build libsvm, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.