### PR TITLE
Re-Implement file parser to also allow loading from in-memory buffers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ svm-scale
 *.mex
 
 octave-workspace
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# binaries
+svm-train
+svm-predict
+svm-scale
+*.o
+*.mex
+
+octave-workspace

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX ?= g++
-CFLAGS = -Wall -Wconversion -O3 -fPIC
+CFLAGS = -Wall -Wconversion -O3 -fPIC -fopenmp -D_OPENMP
 SHVER = 3
 OS = $(shell uname)
 ifeq ($(OS),Darwin)

--- a/matlab/Makefile
+++ b/matlab/Makefile
@@ -6,7 +6,7 @@ MATLABDIR ?= /usr/local/matlab
 
 CXX ?= g++
 #CXX = g++-4.1
-CFLAGS = -Wall -Wconversion -O3 -fPIC -I$(MATLABDIR)/extern/include -I..
+CFLAGS = -Wall -Wconversion -O3 -fPIC -I$(MATLABDIR)/extern/include -I.. -fopenmp -D_OPENMP
 
 MEX = $(MATLABDIR)/bin/mex
 MEX_OPTION = CC="$(CXX)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CFLAGS)"

--- a/svm.cpp
+++ b/svm.cpp
@@ -7,6 +7,10 @@
 #include <stdarg.h>
 #include <limits.h>
 #include <locale.h>
+#include <thread>
+#include <fstream>
+#include <sstream>
+#include <vector>
 #include "svm.h"
 #ifdef _OPENMP
 #include <omp.h>
@@ -2862,264 +2866,7 @@ int svm_save_model(const char *model_file_name, const svm_model *model)
 	else return 0;
 }
 
-static char *line = NULL;
-static int max_line_len;
 
-static char* readline(FILE *input)
-{
-	int len;
-
-	if(fgets(line,max_line_len,input) == NULL)
-		return NULL;
-
-	while(strrchr(line,'\n') == NULL)
-	{
-		max_line_len *= 2;
-		line = (char *) realloc(line,max_line_len);
-		len = (int) strlen(line);
-		if(fgets(line+len,max_line_len-len,input) == NULL)
-			break;
-	}
-	return line;
-}
-
-//
-// FSCANF helps to handle fscanf failures.
-// Its do-while block avoids the ambiguity when
-// if (...)
-//    FSCANF();
-// is used
-//
-#define FSCANF(_stream, _format, _var) do{ if (fscanf(_stream, _format, _var) != 1) return false; }while(0)
-bool read_model_header(FILE *fp, svm_model* model)
-{
-	svm_parameter& param = model->param;
-	// parameters for training only won't be assigned, but arrays are assigned as NULL for safety
-	param.nr_weight = 0;
-	param.weight_label = NULL;
-	param.weight = NULL;
-
-	char cmd[81];
-	while(1)
-	{
-		FSCANF(fp,"%80s",cmd);
-
-		if(strcmp(cmd,"svm_type")==0)
-		{
-			FSCANF(fp,"%80s",cmd);
-			int i;
-			for(i=0;svm_type_table[i];i++)
-			{
-				if(strcmp(svm_type_table[i],cmd)==0)
-				{
-					param.svm_type=i;
-					break;
-				}
-			}
-			if(svm_type_table[i] == NULL)
-			{
-				fprintf(stderr,"unknown svm type.\n");
-				return false;
-			}
-		}
-		else if(strcmp(cmd,"kernel_type")==0)
-		{
-			FSCANF(fp,"%80s",cmd);
-			int i;
-			for(i=0;kernel_type_table[i];i++)
-			{
-				if(strcmp(kernel_type_table[i],cmd)==0)
-				{
-					param.kernel_type=i;
-					break;
-				}
-			}
-			if(kernel_type_table[i] == NULL)
-			{
-				fprintf(stderr,"unknown kernel function.\n");
-				return false;
-			}
-		}
-		else if(strcmp(cmd,"degree")==0)
-			FSCANF(fp,"%d",&param.degree);
-		else if(strcmp(cmd,"gamma")==0)
-			FSCANF(fp,"%lf",&param.gamma);
-		else if(strcmp(cmd,"coef0")==0)
-			FSCANF(fp,"%lf",&param.coef0);
-		else if(strcmp(cmd,"nr_class")==0)
-			FSCANF(fp,"%d",&model->nr_class);
-		else if(strcmp(cmd,"total_sv")==0)
-			FSCANF(fp,"%d",&model->l);
-		else if(strcmp(cmd,"rho")==0)
-		{
-			int n = model->nr_class * (model->nr_class-1)/2;
-			model->rho = Malloc(double,n);
-			for(int i=0;i<n;i++)
-				FSCANF(fp,"%lf",&model->rho[i]);
-		}
-		else if(strcmp(cmd,"label")==0)
-		{
-			int n = model->nr_class;
-			model->label = Malloc(int,n);
-			for(int i=0;i<n;i++)
-				FSCANF(fp,"%d",&model->label[i]);
-		}
-		else if(strcmp(cmd,"probA")==0)
-		{
-			int n = model->nr_class * (model->nr_class-1)/2;
-			model->probA = Malloc(double,n);
-			for(int i=0;i<n;i++)
-				FSCANF(fp,"%lf",&model->probA[i]);
-		}
-		else if(strcmp(cmd,"probB")==0)
-		{
-			int n = model->nr_class * (model->nr_class-1)/2;
-			model->probB = Malloc(double,n);
-			for(int i=0;i<n;i++)
-				FSCANF(fp,"%lf",&model->probB[i]);
-		}
-		else if(strcmp(cmd,"prob_density_marks")==0)
-		{
-			int n = 10;	// nr_marks
-			model->prob_density_marks = Malloc(double,n);
-			for(int i=0;i<n;i++)
-				FSCANF(fp,"%lf",&model->prob_density_marks[i]);
-		}
-		else if(strcmp(cmd,"nr_sv")==0)
-		{
-			int n = model->nr_class;
-			model->nSV = Malloc(int,n);
-			for(int i=0;i<n;i++)
-				FSCANF(fp,"%d",&model->nSV[i]);
-		}
-		else if(strcmp(cmd,"SV")==0)
-		{
-			while(1)
-			{
-				int c = getc(fp);
-				if(c==EOF || c=='\n') break;
-			}
-			break;
-		}
-		else
-		{
-			fprintf(stderr,"unknown text in model file: [%s]\n",cmd);
-			return false;
-		}
-	}
-
-	return true;
-
-}
-
-svm_model *svm_load_model(const char *model_file_name)
-{
-	FILE *fp = fopen(model_file_name,"rb");
-	if(fp==NULL) return NULL;
-
-	char *old_locale = setlocale(LC_ALL, NULL);
-	if (old_locale) {
-		old_locale = strdup(old_locale);
-	}
-	setlocale(LC_ALL, "C");
-
-	// read parameters
-
-	svm_model *model = Malloc(svm_model,1);
-	model->rho = NULL;
-	model->probA = NULL;
-	model->probB = NULL;
-	model->prob_density_marks = NULL;
-	model->sv_indices = NULL;
-	model->label = NULL;
-	model->nSV = NULL;
-
-	// read header
-	if (!read_model_header(fp, model))
-	{
-		fprintf(stderr, "ERROR: fscanf failed to read model\n");
-		setlocale(LC_ALL, old_locale);
-		free(old_locale);
-		free(model->rho);
-		free(model->label);
-		free(model->nSV);
-		free(model);
-		return NULL;
-	}
-
-	// read sv_coef and SV
-
-	int elements = 0;
-	long pos = ftell(fp);
-
-	max_line_len = 1024;
-	line = Malloc(char,max_line_len);
-	char *p,*endptr,*idx,*val;
-
-	while(readline(fp)!=NULL)
-	{
-		p = strtok(line,":");
-		while(1)
-		{
-			p = strtok(NULL,":");
-			if(p == NULL)
-				break;
-			++elements;
-		}
-	}
-	elements += model->l;
-
-	fseek(fp,pos,SEEK_SET);
-
-	int m = model->nr_class - 1;
-	int l = model->l;
-	model->sv_coef = Malloc(double *,m);
-	int i;
-	for(i=0;i<m;i++)
-		model->sv_coef[i] = Malloc(double,l);
-	model->SV = Malloc(svm_node*,l);
-	svm_node *x_space = NULL;
-	if(l>0) x_space = Malloc(svm_node,elements);
-
-	int j=0;
-	for(i=0;i<l;i++)
-	{
-		readline(fp);
-		model->SV[i] = &x_space[j];
-
-		p = strtok(line, " \t");
-		model->sv_coef[0][i] = strtod(p,&endptr);
-		for(int k=1;k<m;k++)
-		{
-			p = strtok(NULL, " \t");
-			model->sv_coef[k][i] = strtod(p,&endptr);
-		}
-
-		while(1)
-		{
-			idx = strtok(NULL, ":");
-			val = strtok(NULL, " \t");
-
-			if(val == NULL)
-				break;
-			x_space[j].index = (int) strtol(idx,&endptr,10);
-			x_space[j].value = strtod(val,&endptr);
-
-			++j;
-		}
-		x_space[j++].index = -1;
-	}
-	free(line);
-
-	setlocale(LC_ALL, old_locale);
-	free(old_locale);
-
-	if (ferror(fp) != 0 || fclose(fp) != 0)
-		return NULL;
-
-	model->free_sv = 1;	// XXX
-	return model;
-}
 
 void svm_free_model_content(svm_model* model_ptr)
 {
@@ -3309,4 +3056,240 @@ void svm_set_print_string_function(void (*print_func)(const char *))
 		svm_print_string = &print_string_stdout;
 	else
 		svm_print_string = print_func;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+class SVMModelParserFileSource {
+	std::ifstream buffer;
+
+public:
+	SVMModelParserFileSource(const char* file_path) : buffer(file_path) {}
+
+	bool read_next(std::string& line) {
+		line.clear();
+		char c = 0;
+		while(buffer.read(&c, 1)) {
+			if(c != '\n' && c != ' ') { line.push_back(c); }
+			else { return line.size() > 0; }
+		}
+		return false;
+	}
+	bool read_line(std::string& line) {
+		return static_cast<bool>(std::getline(buffer, line));
+	}
+	template<typename TValue> bool get(TValue& value, char delim = '\n') {
+		if(buffer >> value) {
+			buffer.ignore(1, delim);
+			return true;
+		}
+		return false;
+	}
+	template<typename TValue> bool get_array(TValue* value, size_t len) {
+		for(size_t i = 0; i < len; ++i) {
+			if(!get(value[i], ' ')) { return false; }
+		}
+		return true;
+	}
+};
+
+class SVMModelParserBufferSource {
+	std::istringstream buffer;
+
+public:
+	SVMModelParserBufferSource(const char* buffer, size_t len) : buffer(std::string(buffer, len)) {}
+
+	bool read_next(std::string& line) {
+		line.clear();
+		char c = 0;
+		while(buffer.read(&c, 1)) {
+			if(c != '\n' && c != ' ') { line.push_back(c); }
+			else { return line.size() > 0; }
+		}
+		return false;
+	}
+	bool read_line(std::string& line) {
+		return static_cast<bool>(std::getline(buffer, line));
+	}
+	template<typename TValue> bool get(TValue& value, char delim = '\n') {
+		if(buffer >> value) {
+			buffer.ignore(1, delim);
+			return true;
+		}
+		return false;
+	}
+	template<typename TValue> bool get_array(TValue* value, size_t len) {
+		for(size_t i = 0; i < len; ++i) {
+			if(!get(value[i], ' ')) { return false; }
+		}
+		return true;
+	}
+};
+
+#define exceptAssert(cond, err) if(!(cond)) { throw std::runtime_error(err); }
+template<typename TSource>
+class SVMModelParser {
+	svm_model* model = nullptr;
+	TSource model_source;
+
+public:
+	SVMModelParser(TSource&& model_source) : model_source(std::move(model_source)) {}
+
+	bool parse() {
+		model = Malloc(svm_model, 1);
+		memset(model, 0, sizeof(struct svm_model));
+		try {
+			parse_header();
+			parse_support_vectors();
+		} catch (std::runtime_error& e) {
+			fprintf(stderr, "ERROR: %s", e.what());
+			svm_free_and_destroy_model(&model);
+			return false;
+		}
+		return true;
+	}
+
+	struct svm_model* get_model() {
+		struct svm_model* model = this->model;
+		this->model = nullptr;
+		return model;
+	}
+
+private:
+	void parse_header() {
+		svm_parameter& param = model->param;
+		size_t nr_class_permutations = 0;
+
+		std::string buffer;
+		while(model_source.read_next(buffer) && buffer != "SV") {
+			if(buffer == "svm_type") {
+				exceptAssert(model_source.read_next(buffer), "Failed to read svm_type.");
+				param.svm_type = -1;
+				for(size_t i = 0; svm_type_table[i]; ++i) {
+					if(buffer == svm_type_table[i]) {
+						param.svm_type = i;
+						break;
+					}
+				}
+				exceptAssert(param.svm_type != -1, "Found unknown svm_type");
+			} else if(buffer == "kernel_type") {
+				param.kernel_type = -1;
+				exceptAssert(model_source.read_next(buffer), "Failed to read kernel_type.");
+				for(size_t i = 0; kernel_type_table[i]; ++i) {
+					if(buffer == kernel_type_table[i]) {
+						param.kernel_type = i;
+						break;
+					}
+				}
+				exceptAssert(param.kernel_type != -1, "Found unknown kernel_type");
+			} else if(buffer == "degree") {
+				exceptAssert(model_source.get(param.degree), "Failed to read degree.");
+			} else if(buffer == "gamma") {
+				exceptAssert(model_source.get(param.gamma), "Failed to read gamma.");
+			} else if(buffer == "coef0") {
+				exceptAssert(model_source.get(param.coef0), "Failed to read coef0.");
+			} else if(buffer == "nr_class") {
+				exceptAssert(model_source.get(model->nr_class), "Failed to read nr_class.");
+				nr_class_permutations = model->nr_class * (model->nr_class - 1) / 2;
+			} else if(buffer == "total_sv") {
+				exceptAssert(model_source.get(model->l), "Failed to read total_sv.");
+			} else if(buffer == "rho") {
+				model->rho = Malloc(double, nr_class_permutations);
+				exceptAssert(
+					model_source.get_array(model->rho, nr_class_permutations),
+					"Failed to read rho");
+			} else if(buffer == "label") {
+				model->label = Malloc(int, model->nr_class);
+				exceptAssert(
+					model_source.get_array(model->label, model->nr_class),
+					"Failed to read label");
+			} else if(buffer == "probA") {
+				model->probA = Malloc(double, nr_class_permutations);
+				exceptAssert(
+					model_source.get_array(model->probA, nr_class_permutations),
+					"Failed to read probA");
+			} else if(buffer == "probB") {
+				model->probB = Malloc(double, nr_class_permutations);
+				exceptAssert(
+					model_source.get_array(model->probB, nr_class_permutations),
+					"Failed to read probB");
+			} else if(buffer == "nr_sv") {
+				model->nSV = Malloc(int, model->nr_class);
+				exceptAssert(
+					model_source.get_array(model->nSV, model->nr_class),
+					"Failed to read nr_sv");
+			} else {
+				throw std::runtime_error("Unknown text in model file");
+			}
+		}
+	}
+	void parse_support_vectors() {
+		// prepare sv coefficient structure
+		model->sv_coef = Malloc(double *, model->nr_class - 1);
+		for(size_t i = 0; i < model->nr_class - 1; ++i) {
+			model->sv_coef[i] = Malloc(double, model->l);
+		}
+
+		std::string line_buffer;
+		svm_node node_buffer;
+		std::vector<svm_node> sv_buffer;
+		for(size_t i = 0; i < model->l; ++i) {
+			exceptAssert(model_source.read_line(line_buffer), "Failed to read SVs");
+			std::istringstream line(line_buffer);
+
+			// parse sv coefficients
+			for(size_t c = 0; c < model->nr_class - 1; ++c) {
+				exceptAssert(line >> model->sv_coef[c][i], "Failed to parse SV coefficient");
+			}
+
+			// parse SVs
+			while(line.good() && line >> node_buffer.index) {
+				exceptAssert(line.ignore(1,':') && line >> node_buffer.value, "Failed to read support vector");
+				sv_buffer.push_back(node_buffer);
+			}
+			node_buffer.index = -1;
+			node_buffer.value = 0.0;
+			sv_buffer.push_back(node_buffer);
+		}
+
+		// prepare sv structure
+		// support vectors will be stored within a single memory plane, that is indexed into
+		// by a pointer-array
+
+		// create memory plane that stores the support vectors
+		svm_node* support_vectors = Malloc(svm_node, sv_buffer.size());
+		memcpy(support_vectors, sv_buffer.data(), sizeof(svm_node) * sv_buffer.size());
+		// create and populate the pointer array, that points into the memory plane
+		model->SV = Malloc(svm_node*, model->l);
+		size_t s = 0;
+		for(size_t i = 0; i < sv_buffer.size(); ++i) {
+			model->SV[s++] = &support_vectors[i];
+			while(support_vectors[i].index != -1) { ++i; }
+		}
+
+		model->free_sv = 1; // XXX
+	}
+};
+
+svm_model* svm_load_model(const char* model_file_name) {
+	SVMModelParser<SVMModelParserFileSource> parser(model_file_name);
+	if(!parser.parse()) { return nullptr; }
+	return parser.get_model();
+}
+
+svm_model* svm_parse_model_from_buffer(const char* model_buffer, unsigned int length) {
+	SVMModelParser<SVMModelParserBufferSource> parser({model_buffer, length});
+	if(!parser.parse()) { return nullptr; }
+	return parser.get_model();
 }

--- a/svm.h
+++ b/svm.h
@@ -77,6 +77,7 @@ void svm_cross_validation(const struct svm_problem *prob, const struct svm_param
 
 int svm_save_model(const char *model_file_name, const struct svm_model *model);
 struct svm_model *svm_load_model(const char *model_file_name);
+struct svm_model *svm_parse_model_from_buffer(const char* model_buffer, unsigned int length);
 
 int svm_get_svm_type(const struct svm_model *model);
 int svm_get_nr_class(const struct svm_model *model);

--- a/tools/grid.py
+++ b/tools/grid.py
@@ -283,13 +283,13 @@ class Worker(Thread):
         if options.grid_with_g:
             cmdline += ' -g {0} '.format(g)
         cmdline += ' -v {0} {1} {2} '.format\
-            (options.fold,options.pass_through_string,options.dataset_pathname)
+            (options.fold,options.pass_through_string,'"' + options.dataset_pathname + '"')
         return cmdline
 
 class LocalWorker(Worker):
     def run_one(self,c,g):
         cmdline = self.get_cmd(c,g)
-        result = Popen(cmdline,shell=True,stdout=PIPE,stderr=PIPE,stdin=PIPE).stdout
+        result = Popen(cmdline,shell=True,stdout=PIPE,stdin=PIPE).stdout
         for line in result.readlines():
             if str(line).find('Cross') != -1:
                 return float(line.split()[-1][0:-1])


### PR DESCRIPTION
The current libsvm only allows loading trained svm-models from a file with the given name.
Especially for use in mobile applications, parsing a model from a buffer would be much appreciated.

The PR consists of two commits:
- Commit 1: Implement the parsing using C++ streams, with an abstract source. This should allow to fairly easily implement parsing from arbitrary sources, such as network sockets, files, buffers, or maybe even a on-the-fly unpacked gzip stream.
Add a new public `svm_parse_model_from_buffer` which uses the new parser to parse svm-models from a given buffer.
- Commit 2: Refactor `svm_load_model` to use the new parser.

Correctness of the parser was tested with the following code - which simply compared the same model parsed from a buffer and a file (in between both commits):
```c++
int main() {
	struct svm_model* svmModelFile = svm_load_model("/tmp/cache/activity.model");
	struct svm_model* svmModel = svm_parse_model_from_buffer(MODEL.data(), MODEL.size());
	assert((svmModel == nullptr && svmModelFile == nullptr) || (svmModel != nullptr && svmModelFile != nullptr));
	if(svmModel == nullptr) { return 1; }

	assert(svmModel->l == svmModelFile->l);
	assert(svmModel->nr_class == svmModelFile->nr_class);
	assert(memcmp(&svmModel->param, &svmModelFile->param, sizeof(svm_parameter)) == 0);
	assert(svmModel->free_sv == svmModelFile->free_sv);

	size_t nr_class_permut = svmModel->nr_class * (svmModel->nr_class - 1) / 2;
	for(size_t i = 0; i < nr_class_permut; ++i) {
		assert(svmModel->probA[i] == svmModelFile->probA[i]);
		assert(svmModel->probB[i] == svmModelFile->probB[i]);
		assert(svmModel->rho[i] == svmModelFile->rho[i]);
	}
	for(size_t i = 0; i < svmModel->nr_class; ++i) {
		assert(svmModel->label[i] == svmModelFile->label[i]);
		assert(svmModel->nSV[i] == svmModelFile->nSV[i]);
	}

	for(size_t c = 0; c < svmModel->nr_class - 1; ++c) {
		for(size_t i = 0; i < svmModel->l; ++i) {
			assert(svmModel->sv_coef[c][i] == svmModelFile->sv_coef[c][i]);
		}
	}

	for(size_t i = 0; i < svmModel->l; ++i) {
		struct svm_node* supportVector = svmModelFile->SV[i];
		size_t j = 0;
		for(j; supportVector[j].index != -1; ++j) {
			assert(svmModel->SV[i][j].index == supportVector[j].index);
			assert(svmModel->SV[i][j].value == supportVector[j].value);
		}
		assert(svmModel->SV[i][j].index == supportVector[j].index);
	}

	svm_free_and_destroy_model(&svmModel);
	svm_free_and_destroy_model(&svmModelFile);
}
```