### PR TITLE
Fix test for empty filename in mexFunction

### DIFF
--- a/matlab/libsvmread.c
+++ b/matlab/libsvmread.c
@@ -199,9 +199,9 @@ void mexFunction( int nlhs, mxArray *plhs[],
 
 	mxGetString(prhs[0], filename, mxGetN(prhs[0]) + 1);
 
-	if(filename == NULL)
+	if(filename[0] == '\0')
 	{
-		mexPrintf("Error: filename is NULL\n");
+		mexPrintf("Error: filename is empty\n");
 		return;
 	}
 


### PR DESCRIPTION
GCC says:
```
libsvmread.c: In function 'mexFunction':
libsvmread.c:202:21: warning: the comparison will always evaluate as 'false' for the address of 'filename' will never be NULL [-Waddress]
  202 |         if(filename == NULL)
      |                     ^~
libsvmread.c:191:14: note: 'filename' declared here
  191 |         char filename[256];
      |              ^~~~~~~~
```
