### PR TITLE
Use safer vnsprintf instead of deprecated vsprintf

### DIFF
--- a/svm.cpp
+++ b/svm.cpp
@@ -54,7 +54,7 @@ static void info(const char *fmt,...)
 	char buf[BUFSIZ];
 	va_list ap;
 	va_start(ap,fmt);
-	vsprintf(buf,fmt,ap);
+	vnsprintf(buf, BUFSIZ, fmt, ap);
 	va_end(ap);
 	(*svm_print_string)(buf);
 }


### PR DESCRIPTION
Fixes this warning:
```
/tmp/otsvm/lib/src/LibSVM/svm.cpp:57:2: warning: 'vsprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use vsnprintf(3) instead. [-Wdeprecated-declarations]
        vsprintf(buf,fmt,ap);
        ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/include/stdio.h:207:1: note: 'vsprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use vsnprintf(3) instead.")
^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
```