### PR TITLE
Use a raw string for a string with escapes

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -47,7 +47,7 @@ if sys.platform == "win32":
     kwargs_for_extension.update(
         {
             "define_macros": [("_WIN64", ""), ("_CRT_SECURE_NO_DEPRECATE", "")],
-            "extra_link_args": ["-DEF:{}\svm.def".format(cpp_dir)],
+            "extra_link_args": [r"-DEF:{}\svm.def".format(cpp_dir)],
             "extra_compile_args": ["/openmp"],
         }
     )


### PR DESCRIPTION
Recent versions of python warn about the affected string:
```
<string>:50: SyntaxWarning: invalid escape sequence '\s'
```
