### PR TITLE
Fix libsvm name for Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,11 @@ CFLAGS = -Wall -Wconversion -O3 -fPIC
 SHVER = 4
 OS = $(shell uname)
 ifeq ($(OS),Darwin)
-	SHARED_LIB_FLAG = -dynamiclib -Wl,-install_name,libsvm.so.$(SHVER)
+	LIB_NAME = libsvm.$(SHVER).dylib
+	SHARED_LIB_FLAG = -dynamiclib -Wl,-install_name,@rpath/$(LIB_NAME)
 else
-	SHARED_LIB_FLAG = -shared -Wl,-soname,libsvm.so.$(SHVER)
+	LIB_NAME = libsvm.so.$(SHVER)
+	SHARED_LIB_FLAG = -shared -Wl,-soname,$(LIB_NAME)
 endif
 
 # Uncomment the following lines to enable parallelization with OpenMP
@@ -15,7 +17,7 @@ endif
 all: svm-train svm-predict svm-scale
 
 lib: svm.o
-	$(CXX) $(SHARED_LIB_FLAG) svm.o -o libsvm.so.$(SHVER)
+	$(CXX) $(SHARED_LIB_FLAG) svm.o -o $(LIB_NAME)
 svm-predict: svm-predict.c svm.o
 	$(CXX) $(CFLAGS) svm-predict.c svm.o -o svm-predict -lm
 svm-train: svm-train.c svm.o
@@ -25,4 +27,4 @@ svm-scale: svm-scale.c
 svm.o: svm.cpp svm.h
 	$(CXX) $(CFLAGS) -c svm.cpp
 clean:
-	rm -f *~ svm.o svm-train svm-predict svm-scale libsvm.so.$(SHVER)
+	rm -f *~ svm.o svm-train svm-predict svm-scale $(LIB_NAME)


### PR DESCRIPTION
On macOS, shared libraries are expected to be installed with the naming
convention

    lib$NAME.$SOVERSION.dylib

We also prefix the library install name with `@rpath` to indicate to the
dynamic linker that it should use RPATH to look for `libsvm`. Without
this, the dynamic linker will only search the calling process' current
working directory, which will, in general, not contain `libsvm`.
