### PR TITLE
Fix bug that could cause weights for the positive and negative classes to be incorrectly swapped

### DIFF
--- a/java/libsvm/svm.java
+++ b/java/libsvm/svm.java
@@ -1969,7 +1969,7 @@ public class svm {
 		// However, for two-class sets with -1/+1 labels and -1 appears first,
 		// we swap labels to ensure that internally the binary SVM has positive data corresponding to the +1 instances.
 		//
-		if (nr_class == 2 && label[0] == -1 && label[1] == +1)
+		if (nr_class == 2 && label[0] <= 0 && label[1] > 0)
 		{
 			do {int tmp=label[0]; label[0]=label[1]; label[1]=tmp;} while(false);
 			do {int tmp=count[0]; count[0]=count[1]; count[1]=tmp;} while(false);

--- a/java/libsvm/svm.m4
+++ b/java/libsvm/svm.m4
@@ -1969,7 +1969,7 @@ public class svm {
 		// However, for two-class sets with -1/+1 labels and -1 appears first,
 		// we swap labels to ensure that internally the binary SVM has positive data corresponding to the +1 instances.
 		//
-		if (nr_class == 2 && label[0] == -1 && label[1] == +1)
+		if (nr_class == 2 && label[0] <= 0 && label[1] > 0)
 		{
 			swap(int,label[0],label[1]);
 			swap(int,count[0],count[1]);

--- a/svm.cpp
+++ b/svm.cpp
@@ -2140,7 +2140,7 @@ static void svm_group_classes(const svm_problem *prob, int *nr_class_ret, int **
 	// However, for two-class sets with -1/+1 labels and -1 appears first,
 	// we swap labels to ensure that internally the binary SVM has positive data corresponding to the +1 instances.
 	//
-	if (nr_class == 2 && label[0] == -1 && label[1] == 1)
+	if (nr_class == 2 && label[0] <= 0 && label[1] > 0)
 	{
 		swap(label[0],label[1]);
 		swap(count[0],count[1]);


### PR DESCRIPTION
LIBSVM supports labels like `0` and `1`. For example, in the `Solver::get_C` function, the check is `(y[i] > 0)? Cp : Cn`.

However, the `svm_group_classes` function only checks for `-1` and `1`. If instead, the labels are `0` and `1`, that could cause the classes to be in the wrong order, which would cause the class weights to be in the wrong order.