### PR TITLE
More robust fixes for numerical issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX ?= g++
 CFLAGS = -Wall -Wconversion -O3 -fPIC
-SHVER = 4
+SHVER = 5
 OS = $(shell uname)
 ifeq ($(OS),Darwin)
 	SHARED_LIB_FLAG = -dynamiclib -Wl,-install_name,libsvm.so.$(SHVER)

--- a/matlab/svmtrain.c
+++ b/matlab/svmtrain.c
@@ -46,6 +46,9 @@ void exit_with_help()
 	"-e epsilon : set tolerance of termination criterion (default 0.001)\n"
 	"-h shrinking : whether to use the shrinking heuristics, 0 or 1 (default 1)\n"
 	"-b probability_estimates : whether to train a SVC or SVR model for probability estimates, 0 or 1 (default 0)\n"
+	"-f floatprecision : set the floating-point precision of kernel values (default 0)\n"
+	"  0 -- float\n"
+	"  1 -- double\n"
 	"-wi weight : set the parameter C of class i to weight*C, for C-SVC (default 1)\n"
 	"-v n: n-fold cross validation mode\n"
 	"-q : quiet mode (no outputs)\n"
@@ -125,6 +128,7 @@ int parse_command_line(int nrhs, const mxArray *prhs[], char *model_file_name)
 	param.p = 0.1;
 	param.shrinking = 1;
 	param.probability = 0;
+	param.use_double_precision_kernel_values = 0;
 	param.nr_weight = 0;
 	param.weight_label = NULL;
 	param.weight = NULL;
@@ -187,6 +191,9 @@ int parse_command_line(int nrhs, const mxArray *prhs[], char *model_file_name)
 			case 'b':
 				param.probability = atoi(argv[i]);
 				break;
+			case 'f':
+			   param.use_double_precision_kernel_values = atoi(argv[i]);
+			   break;
 			case 'q':
 				print_func = &print_null;
 				i--;

--- a/python/libsvm/svm.py
+++ b/python/libsvm/svm.py
@@ -240,10 +240,10 @@ class svm_problem(Structure):
 class svm_parameter(Structure):
     _names = ["svm_type", "kernel_type", "degree", "gamma", "coef0",
             "cache_size", "eps", "C", "nr_weight", "weight_label", "weight",
-            "nu", "p", "shrinking", "probability"]
+            "nu", "p", "shrinking", "probability", "use_double_precision_kernel_values"]
     _types = [c_int, c_int, c_int, c_double, c_double,
             c_double, c_double, c_double, c_int, POINTER(c_int), POINTER(c_double),
-            c_double, c_double, c_int, c_int]
+            c_double, c_double, c_int, c_int, c_int]
     _fields_ = genFields(_names, _types)
 
     def __init__(self, options = None):
@@ -274,6 +274,7 @@ class svm_parameter(Structure):
         self.p = 0.1
         self.shrinking = 1
         self.probability = 0
+        self.use_double_precision_kernel_values = 0
         self.nr_weight = 0
         self.weight_label = None
         self.weight = None
@@ -331,6 +332,9 @@ class svm_parameter(Structure):
             elif argv[i] == "-b":
                 i = i + 1
                 self.probability = int(argv[i])
+            elif argv[i] == '-f':
+                i = i + 1
+                self.use_double_precision_kernel_values = int(argv[i])
             elif argv[i] == "-q":
                 self.print_func = PRINT_STRING_FUN(print_null)
             elif argv[i] == "-v":

--- a/python/libsvm/svmutil.py
+++ b/python/libsvm/svmutil.py
@@ -84,6 +84,9 @@ def svm_train(arg1, arg2=None, arg3=None):
         -e epsilon : set tolerance of termination criterion (default 0.001)
         -h shrinking : whether to use the shrinking heuristics, 0 or 1 (default 1)
         -b probability_estimates : whether to train a model for probability estimates, 0 or 1 (default 0)
+	     -f floatprecision : set the floating-point precision of kernel values (default 0)
+	         0 -- float
+	         1 -- double
         -wi weight : set the parameter C of class i to weight*C, for C-SVC (default 1)
         -v n: n-fold cross validation mode
         -q : quiet mode (no outputs)

--- a/svm-train.c
+++ b/svm-train.c
@@ -35,6 +35,9 @@ void exit_with_help()
 	"-e epsilon : set tolerance of termination criterion (default 0.001)\n"
 	"-h shrinking : whether to use the shrinking heuristics, 0 or 1 (default 1)\n"
 	"-b probability_estimates : whether to train a SVC or SVR model for probability estimates, 0 or 1 (default 0)\n"
+	"-f floatprecision : set the floating-point precision of kernel values (default 0)\n"
+	"  0 -- float\n"
+	"  1 -- double\n"
 	"-wi weight : set the parameter C of class i to weight*C, for C-SVC (default 1)\n"
 	"-v n: n-fold cross validation mode\n"
 	"-q : quiet mode (no outputs)\n"
@@ -176,6 +179,7 @@ void parse_command_line(int argc, char **argv, char *input_file_name, char *mode
 	param.p = 0.1;
 	param.shrinking = 1;
 	param.probability = 0;
+	param.use_double_precision_kernel_values = 0;
 	param.nr_weight = 0;
 	param.weight_label = NULL;
 	param.weight = NULL;
@@ -225,6 +229,9 @@ void parse_command_line(int argc, char **argv, char *input_file_name, char *mode
 			case 'b':
 				param.probability = atoi(argv[i]);
 				break;
+			case 'f':
+			   param.use_double_precision_kernel_values = atoi(argv[i]);
+			   break;
 			case 'q':
 				print_func = &print_null;
 				i--;

--- a/svm.cpp
+++ b/svm.cpp
@@ -198,7 +198,7 @@ void Cache::swap_index(int i, int j)
 class QMatrix {
 public:
 	virtual Qfloat *get_Q(int column, int len) const = 0;
-	virtual double *get_QD() const = 0;
+	virtual Qfloat *get_QD() const = 0;
 	virtual void swap_index(int i, int j) const = 0;
 	virtual ~QMatrix() {}
 };
@@ -211,7 +211,7 @@ public:
 	static double k_function(const svm_node *x, const svm_node *y,
 				 const svm_parameter& param);
 	virtual Qfloat *get_Q(int column, int len) const = 0;
-	virtual double *get_QD() const = 0;
+	virtual Qfloat *get_QD() const = 0;
 	virtual void swap_index(int i, int j) const	// no so const...
 	{
 		swap(x[i],x[j]);
@@ -418,7 +418,7 @@ protected:
 	char *alpha_status;	// LOWER_BOUND, UPPER_BOUND, FREE
 	double *alpha;
 	const QMatrix *Q;
-	const double *QD;
+	const Qfloat *QD;
 	double eps;
 	double Cp,Cn;
 	double *p;
@@ -1275,7 +1275,7 @@ public:
 	{
 		clone(y,y_,prob.l);
 		cache = new Cache(prob.l,(size_t)(param.cache_size*(1<<20)));
-		QD = new double[prob.l];
+		QD = new Qfloat[prob.l];
 		for(int i=0;i<prob.l;i++)
 			QD[i] = (this->*kernel_function)(i,i);
 	}
@@ -1295,7 +1295,7 @@ public:
 		return data;
 	}
 
-	double *get_QD() const
+	Qfloat *get_QD() const
 	{
 		return QD;
 	}
@@ -1317,7 +1317,7 @@ public:
 private:
 	schar *y;
 	Cache *cache;
-	double *QD;
+	Qfloat *QD;
 };
 
 class ONE_CLASS_Q: public Kernel
@@ -1327,7 +1327,7 @@ public:
 	:Kernel(prob.l, prob.x, param)
 	{
 		cache = new Cache(prob.l,(size_t)(param.cache_size*(1<<20)));
-		QD = new double[prob.l];
+		QD = new Qfloat[prob.l];
 		for(int i=0;i<prob.l;i++)
 			QD[i] = (this->*kernel_function)(i,i);
 	}
@@ -1344,7 +1344,7 @@ public:
 		return data;
 	}
 
-	double *get_QD() const
+	Qfloat *get_QD() const
 	{
 		return QD;
 	}
@@ -1363,7 +1363,7 @@ public:
 	}
 private:
 	Cache *cache;
-	double *QD;
+	Qfloat *QD;
 };
 
 class SVR_Q: public Kernel
@@ -1374,7 +1374,7 @@ public:
 	{
 		l = prob.l;
 		cache = new Cache(l,(size_t)(param.cache_size*(1<<20)));
-		QD = new double[2*l];
+		QD = new Qfloat[2*l];
 		sign = new schar[2*l];
 		index = new int[2*l];
 		for(int k=0;k<l;k++)
@@ -1420,7 +1420,7 @@ public:
 		return buf;
 	}
 
-	double *get_QD() const
+	Qfloat *get_QD() const
 	{
 		return QD;
 	}
@@ -1441,7 +1441,7 @@ private:
 	int *index;
 	mutable int next_buffer;
 	Qfloat *buffer[2];
-	double *QD;
+	Qfloat *QD;
 };
 
 //

--- a/svm.h
+++ b/svm.h
@@ -44,6 +44,7 @@ struct svm_parameter
 	double p;	/* for EPSILON_SVR */
 	int shrinking;	/* use the shrinking heuristics */
 	int probability; /* do probability estimates */
+	int use_double_precision_kernel_values;
 };
 
 //


### PR DESCRIPTION
# Commit 1: Fix inconsistency that could cause the optimization algorithm to oscillate.

Fixes https://github.com/cjlin1/libsvm/issues/225.

## Background

The optimization algorithm has three main calculations:
1. Select the working set `{i, j}` that [minimizes](https://github.com/cjlin1/libsvm/blob/35e55962f7f03ce425bada0e6b9db79193e947f8/svm.cpp#L829-L879) the decrease in the objective function.
2. Change `alpha[i]` and `alpha[j]` to [minimize](https://github.com/cjlin1/libsvm/blob/35e55962f7f03ce425bada0e6b9db79193e947f8/svm.cpp#L606-L691) the decrease in the objective function while respecting constraints.
3. [Update](https://github.com/cjlin1/libsvm/blob/35e55962f7f03ce425bada0e6b9db79193e947f8/svm.cpp#L698-L701) the gradient of the objective function according to the changes to `alpha[i]` and `alpha[j]`.

All three calculations make use of the matrix `Q`, which is represented by the `QMatrix` [class](https://github.com/cjlin1/libsvm/blob/35e55962f7f03ce425bada0e6b9db79193e947f8/svm.cpp#L198). The `QMatrix` class has two main methods:
- `get_Q`, which returns an array of values for a single column of the matrix; and
- `get_QD`, which returns an array of diagonal values.

## Problem

`Q` values are of type `Qfloat` while `QD` values are of type `double`. `Qfloat` is currently [defined](https://github.com/cjlin1/libsvm/blob/35e55962f7f03ce425bada0e6b9db79193e947f8/svm.cpp#L16) as `float`, so there can be inconsistency in the diagonal values returned by `get_Q` and `get_QD`. For example, in https://github.com/cjlin1/libsvm/issues/225, one of the diagonal values is `181.05748749793070829` as `double` and `180.99411909539512067` as `float`.

The first two calculations of the optimization algorithm access the diagonal values via `get_QD`. However, the third calculation accesses the diagonal values via `get_Q`. This inconsistency between the minimization calculations and the gradient update can cause the optimization algorithm to oscillate, as demonstrated by https://github.com/cjlin1/libsvm/issues/225.

## Solution

We change the type of `QD` values from `double` to `Qfloat`. This guarantees that all calculations are using the same values for the diagonal elements, eliminating the inconsistency.

Note that this reverts the past commit https://github.com/cjlin1/libsvm/commit/1c80a4235df353854e195bf309b8bcd2ed8a09b6. That commit changed the type of `QD` values from `Qfloat` to `double` to address a numerical issue. In a follow-up commit, we will allow `Qfloat` to be defined as `double` at runtime as a more general fix for numerical issues.

## Future Changes

The Java code will be updated similarly in a separate commit.

# Commit 2: Add a runtime parameter to specify the floating-point precision of kernel values.

This will make it easier for users to try double precision kernel values when they run into numerical issues.