### PR TITLE
Added numpy 2.x compatibility

### DIFF
--- a/python/libsvm/svm.py
+++ b/python/libsvm/svm.py
@@ -131,11 +131,11 @@ def gen_svm_nodearray(xi, feature_max=None, isKernel=False):
         # since xi=(indices, values), we must sort them simultaneously.
         for idx, arg in enumerate(np.argsort(index_range)):
             ret[idx].index = index_range[arg]
-            ret[idx].value = (xi[1])[arg]
+            ret[idx].value = (xi[1])[arg].item()
     else:
         for idx, j in enumerate(index_range):
             ret[idx].index = j
-            ret[idx].value = xi[j - xi_shift]
+            ret[idx].value = xi[j - xi_shift].item()
 
     max_idx = 0
     if len(index_range) > 0:


### PR DESCRIPTION
There is an issue when assigning 1-element numpy array to a float variable in numpy 2.x. Adding `.item()` will work for numpy 1.x and 2.x.